### PR TITLE
Replace Timeout.timeout with socket timeout

### DIFF
--- a/lib/net/pop.rb
+++ b/lib/net/pop.rb
@@ -540,8 +540,11 @@ module Net
 
     # internal method for Net::POP3.start
     def do_start(account, password) # :nodoc:
-      s = Timeout.timeout(@open_timeout, Net::OpenTimeout) do
-        TCPSocket.open(@address, port)
+      begin
+        s = Socket.tcp @address, port, nil, nil, connect_timeout: @open_timeout
+      rescue Errno::ETIMEDOUT #raise Net:OpenTimeout instead for compatibility with previous versions
+        raise Net::OpenTimeout, "Timeout to open TCP connection to "\
+            "#{@address}:#{port} (exceeds #{@open_timeout} seconds)"
       end
       if use_ssl?
         raise 'openssl library not installed' unless defined?(OpenSSL)


### PR DESCRIPTION
Timeout.timeout is inefficient since it spins up a new thread for each invocation, use Socket.tcp's connect_timeout option instead