### PR TITLE
Remove needless dependencies

### DIFF
--- a/net-pop.gemspec
+++ b/net-pop.gemspec
@@ -29,6 +29,4 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "net-protocol"
-  spec.add_dependency "digest"
-  spec.add_dependency "timeout"
 end


### PR DESCRIPTION
These are default gems, so there is no need to explicitly depend on them,
and depending on them is actually harmful: https://bugs.ruby-lang.org/issues/18567.