### PR TITLE
Add support for CAPA command

### DIFF
--- a/test/net/pop/test_pop.rb
+++ b/test/net/pop/test_pop.rb
@@ -93,6 +93,40 @@ class TestPOP < Test::Unit::TestCase
     assert_not_predicate res, :frozen?
   end
 
+  test "CAPA" do
+    pop_test do |pop|
+      pop.start(@ok_user, @users[@ok_user]) do |pop|
+        assert_equal(
+          {
+            "TOP" => [], "USER" => [], "STLS" => [], "EXPIRE" => ["60"],
+            "IMPLEMENTATION" => %w[BLURDYBLURP POP3 SERVER],
+            "SASL" => %w[PLAIN OAUTHBEARER XOAUTH DIGEST-MD5 GSSAPI ANONYMOUS],
+          },
+          pop.capabilities
+        )
+
+        assert_equal ["60"], pop.capable?("expire")
+
+        assert pop.capable?("TOP")
+        assert pop.capable?("user")
+        assert_same true, pop.capable?("Implementation", "POP3")
+
+        assert_same nil, pop.capable?("UTF-8")
+        assert_same nil, pop.capable?("UTF-8", "USER")
+
+        assert_kind_of Array, pop.sasl_capable?
+        assert_same    true,  pop.sasl_capable?("PLAIN")
+        assert_same    false, pop.sasl_capable?("CRAM-MD5")
+        assert_equal %w[PLAIN OAUTHBEARER XOAUTH DIGEST-MD5 GSSAPI ANONYMOUS],
+                     pop.sasl_mechanisms
+
+        refute pop.capable? "PIPELINING"
+        refute pop.capable?("Implementation", "POP4")
+        refute pop.sasl_capable? "CRAM-MD5"
+      end
+    end
+  end
+
   def pop_test(apop=false)
     host = 'localhost'
     server = TCPServer.new(host, 0)
@@ -134,6 +168,17 @@ class TestPOP < Test::Unit::TestCase
     user = nil
     while line = sock.gets
       case line
+      when /\ACAPA\r\n\z/i
+        (<<~CAPA).each_line { sock.print "#{_1.chop}\r\n" }
+          +OK List of capabilities follows
+          TOP
+          USER
+          SASL PLAIN OAUTHBEARER XOAUTH DIGEST-MD5 GSSAPI ANONYMOUS
+          STLS
+          IMPLEMENTATION BlurdyBlurp POP3 server
+          EXPIRE 60
+          .
+        CAPA
       when /^USER (.+)\r\n/
         user = $1
         if @users.key?(user)


### PR DESCRIPTION
This adds support for asking a POP server about its capabilities ([RFC2449]).

* Adds Net::POP3Command#capa, which issues the CAPA command and encodes the result as a hash of {tag => params for tag, *params in each_list_item}.  Tags and params are both upcased, to simplify case insensitive matching.
* Adds Net::POP3#capabilities, which caches the result from `command.capa`.
* Adds Net::POP3#capable?, which returns whether #capabilities includes a specific `tag` and `param`.
* Adds Net::POP3#clear_cached_capabilities, which clears the capabilities cache.
* Adds Net::POP3#sasl_capable? and Net::POP3#sasl_mechanisms, which query support of the "SASL" capabability.

Note that the `STLS` extension modifies the CAPA requirements.  If support is added for `STLS`, the capabilities cache must be reset.

----

This is needed in order to properly support SASL authentication using the `AUTH` command ([RFC5034]).

And a basic SASL implementation should be the basis for supporting OAuth2 (whether via the non-standard [XOAUTH2] SASL mechanism or the standard [OAUTHBEARER] SASL mechanism).  Therefore, `CAPA` is a requirement for proper implementation of OAuth2.

[RFC2449]: https://datatracker.ietf.org/doc/html/rfc2449
[RFC5034]: https://datatracker.ietf.org/doc/html/rfc5034
[XOAUTH2]: https://developers.google.com/gmail/imap/xoauth2-protocol
[OAUTHBEARER]: https://www.rfc-editor.org/rfc/rfc6750.html