### PR TITLE
Add Net::POP3#enable_starttls for support STARTTLS

### DIFF
--- a/test/net/pop/test_pop.rb
+++ b/test/net/pop/test_pop.rb
@@ -10,6 +10,23 @@ class TestPOP < Test::Unit::TestCase
     @stamp_base = "#{$$}.#{Time.now.to_i}@localhost"
   end
 
+  def test_default_port
+    pop = Net::POP3.new('localhost')
+    assert_equal pop.port, 110
+  end
+
+  def test_ssl_default_port
+    pop = Net::POP3.new('localhost')
+    pop.enable_ssl
+    assert_equal pop.port, 995
+  end
+
+  def test_starttls_default_port
+    pop = Net::POP3.new('localhost')
+    pop.enable_starttls
+    assert_equal pop.port, 110
+  end
+
   def test_pop_auth_ok
     pop_test(false) do |pop|
       assert_instance_of Net::POP3, pop


### PR DESCRIPTION
The `Net::POP3#enable_starttls` method supports the POP3 STARTTLS extension [RFC 2595].

* https://github.com/ruby/net-pop/issues/14

I believe it is valuable to offer a secure option for port 110 access because there are still many servers that support STARTTLS.
My own motivation for this feature is to ensure the correct settings for the POP servers I have set up.

I have tried to keep this PR as concise as possible.

I chose the term `starttls` instead of `startssl` because the STLS command means STARTTLS.

`Net::POP3#enable_starttls` shares `@ssl_params` with `Net::POP3#enable_ssl` (pop3s) to reduce code changes.

Its usage is the same as `Net::POP3#enable_ssl`.
`Net::POP3#enable_starttls` must also be called before the connection is established.

Example:
```ruby
pop = Net::POP3.new("pop.example.com")
pop.set_debug_output $stderr
pop.enable_starttls
pop.start("account", "password") do |c|
  c.mails
end
```

Example session:
```
POP session started: pop.example.com: (POP)
-> "+OK Dovecot ready.\r\n"
<- "STLS\r\n"
-> "+OK Begin TLS negotiation now.\r\n"
<- "USER account\r\n"
-> "+OK\r\n"
<- "PASS password\r\n"
-> "+OK Logged in.\r\n"
<- "STAT\r\n"
-> "+OK 9 7191\r\n"
<- "LIST\r\n"
-> "+OK 9 messages:\r\n"
-> "1 1097\r\n"
… (omitted)
-> "9 750\r\n"
-> ".\r\n"
<- "QUIT\r\n"
-> "+OK Logging out.\r\n"
```

(I wish I could implement a feature where `Net::POP3#enable_starttls` can be called after the connection.
However, I decided against it because `Net::POP3#start` includes the authentication process, and implementing such a feature would require more extensive code changes.)

Regarding tests, I was unsure how to test TLS connections, so I only added tests for the default ports.

Thank you for maintaining this useful gem!