### PR TITLE
Reject CR/LF in POP3 command arguments

### DIFF
--- a/lib/net/pop.rb
+++ b/lib/net/pop.rb
@@ -984,13 +984,20 @@ module Net
     private
 
     def getok(fmt, *fargs)
-      @socket.writeline sprintf(fmt, *fargs)
+      @socket.writeline validate_line(sprintf(fmt, *fargs))
       check_response(recv_response())
     end
 
     def get_response(fmt, *fargs)
-      @socket.writeline sprintf(fmt, *fargs)
+      @socket.writeline validate_line(sprintf(fmt, *fargs))
       recv_response()
+    end
+
+    def validate_line(line)
+      if /[\r\n]/.match?(line)
+        raise ArgumentError, "POP3 command cannot include CR/LF"
+      end
+      line
     end
 
     def recv_response

--- a/test/net/pop/test_pop.rb
+++ b/test/net/pop/test_pop.rb
@@ -64,6 +64,30 @@ class TestPOP < Test::Unit::TestCase
     end
   end
 
+  def test_pop_user_crlf_injection
+    pop_test(false) do |pop|
+      assert_raise ArgumentError do
+        pop.start("user\r\nDELE 1", @users[@ok_user])
+      end
+    end
+  end
+
+  def test_pop_pass_crlf_injection
+    pop_test(false) do |pop|
+      assert_raise ArgumentError do
+        pop.start(@ok_user, "pass\r\nDELE 1")
+      end
+    end
+  end
+
+  def test_apop_crlf_injection
+    pop_test(@stamp_base) do |pop|
+      assert_raise ArgumentError do
+        pop.start("user\r\nDELE 1", @users[@ok_user])
+      end
+    end
+  end
+
   def test_popmail
     # totally not representative of real messages, but
     # enough to test frozen bugs


### PR DESCRIPTION
The account and password passed to USER, PASS, and APOP were interpolated into command lines without rejecting CR/LF, so an application forwarding untrusted input as login arguments could inject arbitrary POP3 commands. Add the same validate_line guard already present in net-smtp and net-ftp.

As with https://github.com/ruby/net-http/pull/301, these are ordinary bugs rather than vulnerabilities, since the affected inputs are supplied by the application itself.